### PR TITLE
Add a Github action to Whitehole + fixes the compile time error

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -22,9 +22,7 @@ jobs:
     - name: Insatll cURL
       run: choco install curl --acceptlicense --confirm
     - name: Build Whitehole
-      run: ant -Dnb.internal.action.name=build jar
-    - name: Run Zip.cmd
-      run: Zip.cmd
+      run: Build.cmd
       shell: cmd
     - name: Upload Files
       uses: actions/upload-artifact@v2

--- a/Build.cmd
+++ b/Build.cmd
@@ -1,4 +1,5 @@
 pushd %CD%
+ant -Dnb.internal.action.name=build jar
 cd dist
 rm -f README.TXT
 curl -k -L http://kuribo64.net/whitehole/objectdb.php -o objectdb.xml

--- a/Zip.cmd
+++ b/Zip.cmd
@@ -1,0 +1,7 @@
+pushd %CD%
+cd dist
+rm -f README.TXT
+curl -k -L http://kuribo64.net/whitehole/objectdb.php -o objectdb.xml
+7z a ../Build.zip *.* -r
+popd
+echo Complete.

--- a/src/com/thesuncat/whitehole/swing/GalaxyEditorForm.java
+++ b/src/com/thesuncat/whitehole/swing/GalaxyEditorForm.java
@@ -4569,6 +4569,12 @@ public class GalaxyEditorForm extends javax.swing.JFrame {
         }
         glCanvas.repaint();
     }
+
+    static class DarkJMenuBar extends JMenuBar {
+
+        public DarkJMenuBar() {
+        }
+    }
     
     public class GalaxyRenderer implements GLEventListener, MouseListener, MouseMotionListener, MouseWheelListener, KeyListener {
 


### PR DESCRIPTION
This PR adds a github action and shell script to build Whitehole automatically when a commit is pushed to the master branch.
It also fixes the compiler error of a missing class in one of the editor forms.